### PR TITLE
Add go.mod to unblock CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/psbx/go-http-ping
+
+go 1.22


### PR DESCRIPTION
## Summary
- add a go.mod with module path github.com/psbx/go-http-ping to enable module-aware builds in CI

## Testing
- not run (rely on CI)